### PR TITLE
Implement `latexescape`

### DIFF
--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -6,7 +6,7 @@ in supporting environments like IJulia.
 See in particular the `LaTeXString` type and the `L"..."` constructor macro.
 """
 module LaTeXStrings
-export LaTeXString, latexstring, @L_str
+export LaTeXString, latexstring, @L_str, latexescape
 
 # IJulia supports LaTeX output for any object with a text/latex
 # writemime method, but these are annoying to type as string literals
@@ -132,5 +132,34 @@ Base.unsafe_convert(T::Union{Type{Ptr{UInt8}},Type{Ptr{Int8}},Cstring}, s::LaTeX
 Base.match(re::Regex, s::LaTeXString, idx::Integer, add_opts::UInt32=UInt32(0)) = match(re, s.s, idx, add_opts)
 Base.findnext(re::Regex, s::LaTeXString, idx::Integer) = findnext(re, s.s, idx)
 Base.eachmatch(re::Regex, s::LaTeXString; overlap = false) = eachmatch(re, s.s; overlap=overlap)
+
+const LATEX_ESCAPE_SUB_TABLE = Pair{String,String}[
+    raw"\\" => raw"\textbackslash{}",
+    raw"&" => raw"\&",
+    raw"%" => raw"\%",
+    raw"$" => raw"\$",
+    raw"#" => raw"\#",
+    raw"_" => raw"\_",
+    raw"{" => raw"\{",
+    raw"}" => raw"\}",
+    raw"~" => raw"\textasciitilde{}",
+    raw"^" => raw"\^{}",
+    raw"<" => raw"\textless{}",
+    raw">" => raw"\textgreater{}",
+]
+
+@doc raw"""
+    latexscape(s::AbstractString)
+
+This function escapes common text so it can be included directly into ``\TeX`` code[^so16259923].
+
+## References
+
+[^so16259923]:
+    Stack Overflow: ["How can I escape LaTeX special characters inside django templates?"](https://stackoverflow.com/questions/16259923)
+"""
+function latexescape(s::AbstractString)
+    return replace(s, LATEX_ESCAPE_SUB_TABLE...)
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,10 @@ end
     @test tst1[OneTo(5)] == tst1[1:5]
 end
 
+@testset "escaping" begin
+    @test latexescape(raw"A\&%$#_{}~^<>z") == raw"A\textbackslash{}\&\%\$\#\_\{\}\textasciitilde{}\^{}\textless{}\textgreater{}z"
+end
+
 using Documenter
 DocMeta.setdocmeta!(LaTeXStrings, :DocTestSetup, :(using LaTeXStrings); recursive=true)
 doctest(LaTeXStrings; manual = false)


### PR DESCRIPTION
This PR aims to close #33 and implement string escaping for common text to be included directly into TeX files.

- Method `latexescape(s::AbstractString)` was added and exported
- A test case was added