### PR TITLE
Fix invalidations by removing unnecessary methods

### DIFF
--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -105,16 +105,11 @@ function Base.show(io::IO, s::LaTeXString)
     end
 end
 
-Base.firstindex(s::LaTeXString) = firstindex(s.s)
-Base.lastindex(s::LaTeXString) = lastindex(s.s)
 Base.iterate(s::LaTeXString, i::Int) = iterate(s.s, i)
 Base.iterate(s::LaTeXString) = iterate(s.s)
-Base.nextind(s::LaTeXString, i::Int) = nextind(s.s, i)
 Base.prevind(s::LaTeXString, i::Int) = prevind(s.s, i)
 Base.eachindex(s::LaTeXString) = eachindex(s.s)
 Base.length(s::LaTeXString) = length(s.s)
-Base.getindex(s::LaTeXString, i::Integer) = getindex(s.s, i)
-Base.getindex(s::LaTeXString, i::Int) = getindex(s.s, i) # for method ambig in Julia 0.6
 Base.getindex(s::LaTeXString, i::UnitRange{Int}) = getindex(s.s, i)
 Base.getindex(s::LaTeXString, i::UnitRange{<:Integer}) = getindex(s.s, i)
 Base.getindex(s::LaTeXString, i::AbstractUnitRange{<:Integer}) = getindex(s.s, i) # for method ambiguity
@@ -124,13 +119,11 @@ Base.codeunit(s::LaTeXString, i::Integer) = codeunit(s.s, i)
 Base.codeunit(s::LaTeXString) = codeunit(s.s)
 Base.ncodeunits(s::LaTeXString) = ncodeunits(s.s)
 Base.codeunits(s::LaTeXString) = codeunits(s.s)
-Base.sizeof(s::LaTeXString) = sizeof(s.s)
 Base.isvalid(s::LaTeXString, i::Integer) = isvalid(s.s, i)
 Base.pointer(s::LaTeXString) = pointer(s.s)
 Base.IOBuffer(s::LaTeXString) = IOBuffer(s.s)
 Base.unsafe_convert(T::Union{Type{Ptr{UInt8}},Type{Ptr{Int8}},Cstring}, s::LaTeXString) = Base.unsafe_convert(T, s.s)
 Base.match(re::Regex, s::LaTeXString, idx::Integer, add_opts::UInt32=UInt32(0)) = match(re, s.s, idx, add_opts)
 Base.findnext(re::Regex, s::LaTeXString, idx::Integer) = findnext(re, s.s, idx)
-Base.eachmatch(re::Regex, s::LaTeXString; overlap = false) = eachmatch(re, s.s; overlap=overlap)
 
 end # module


### PR DESCRIPTION
There are currently 35 unique methods being invalidated. This PR fixes 31 of these by deleting methods that have pre-existing implementations defined in terms of the remaining methods. I am uncertain of the source of the remaining 4 invalidations. Users and dependents of this package will benefit from decreased latency from needing to recompile up to 31 methods.

Note that I deleted `getindex(::LaTeXString, ::Int)`, which states to resolve a method ambiguity in Julia 0.6. This version was released over 6 years ago and is pre-1.0, so I support having reduced latency for current users over maintaining that support. However, I would be happy to redefine that method upon request.

See also #64.

### Before
```julia
~> julia --startup-file=no --banner=no
(@v1.9) pkg> activate debug
  Activating project at `~/debug`

julia> using SnoopCompileCore

julia> invalidations = @snoopr using LaTeXStrings;

julia> using SnoopCompile

julia> length(uinvalidated(invalidations))
35

julia> trees = invalidation_trees(invalidations)
6-element Vector{SnoopCompile.MethodInvalidations}:
 inserting firstindex(s::LaTeXString) @ LaTeXStrings ~/.julia/packages/LaTeXStrings/ZtSdh/src/LaTeXStrings.jl:108 invalidated:
   backedges: 1: superseding firstindex(s::AbstractString) @ Base strings/basic.jl:180 with MethodInstance for firstindex(::AbstractString) (1 children)
   7 mt_cache

 inserting eachmatch(re::Regex, s::LaTeXString; overlap) @ LaTeXStrings ~/.julia/packages/LaTeXStrings/ZtSdh/src/LaTeXStrings.jl:134 invalidated:
   backedges: 1: superseding eachmatch(re::Regex, str::AbstractString; overlap) @ Base regex.jl:712 with MethodInstance for eachmatch(::Regex, ::AbstractString) (2 children)

 inserting sizeof(s::LaTeXString) @ LaTeXStrings ~/.julia/packages/LaTeXStrings/ZtSdh/src/LaTeXStrings.jl:127 invalidated:
   backedges: 1: superseding sizeof(s::AbstractString) @ Base strings/basic.jl:179 with MethodInstance for sizeof(::AbstractString) (4 children)

 inserting getindex(s::LaTeXString, i::Int64) @ LaTeXStrings ~/.julia/packages/LaTeXStrings/ZtSdh/src/LaTeXStrings.jl:117 invalidated:
   backedges: 1: superseding getindex(s::AbstractString, i::Integer) @ Base strings/basic.jl:184 with MethodInstance for getindex(::AbstractString, ::Int64) (5 children)

 inserting lastindex(s::LaTeXString) @ LaTeXStrings ~/.julia/packages/LaTeXStrings/ZtSdh/src/LaTeXStrings.jl:109 invalidated:
   backedges: 1: superseding lastindex(s::AbstractString) @ Base strings/basic.jl:181 with MethodInstance for lastindex(::AbstractString) (5 children)

 inserting nextind(s::LaTeXString, i::Int64) @ LaTeXStrings ~/.julia/packages/LaTeXStrings/ZtSdh/src/LaTeXStrings.jl:112 invalidated:
   backedges: 1: superseding nextind(s::AbstractString, i::Int64) @ Base strings/basic.jl:556 with MethodInstance for nextind(::AbstractString, ::Int64) (19 children)
```

### After
```julia
~/Documents/Programming/forks/LaTeXStrings.jl> julia --startup-file=no --banner=no
(@v1.9) pkg> activate debug
  Activating project at `~/debug`

(debug) pkg> st
Status `~/debug/Project.toml`
  [b964fa9f] LaTeXStrings v1.3.1 `..`
  [aa65fe97] SnoopCompile v2.10.8
  [e2b509da] SnoopCompileCore v2.10.0

julia> using SnoopCompileCore

julia> invalidations = @snoopr using LaTeXStrings;

julia> using SnoopCompile

julia> length(uinvalidated(invalidations))
4

julia> trees = invalidation_trees(invalidations)
SnoopCompile.MethodInvalidations[]
```
